### PR TITLE
用意した効果音をバイナリに埋め込むようにした

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /be
-data/*.wav
-data/*.h
-data/raw/*
+sounds/*.wav
+sounds/*.h
+sounds/raw/*
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /be
 data/*.wav
+data/*.h
 data/raw/*
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 data/*.wav
 data/raw/*
 .DS_Store
+*.o

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 data/*.wav
 data/raw/*
 .DS_Store
-*.o

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,17 @@ CC=g++
 CFLAGS=-O -Wall
 
 .PHONY: all
-all: build install
+all: build
+
+data/ses.h: data/shinobi_execution_se.wav
+	xxd -i data/shinobi_execution_se.wav > data/ses.h
 
 .PHONY: build
-build: be.cpp be.h
+build: be.cpp be.h data/ses.h
 	$(CC) $(CFLAGS) -o be be.cpp -lncurses -framework OpenAL
 
 .PHONY: install
-install:
+install: build
 	mkdir -p ${HOME}/.local/bin
 	mv be ${HOME}/.local/bin/be
 	echo 'Installed to ${HOME}/.local/bin'

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,17 @@ CC=g++
 CFLAGS=-O -Wall
 
 .PHONY: all
-all: build install
+all: be install
 
-.PHONY: build
-build: be.cpp be.h
-	$(CC) $(CFLAGS) -o be be.cpp -lncurses -framework OpenAL
+se.o: data/se.wav
+	gobjcopy -S -I binary -O mach-o-x86-64 data/se.wav se.o
+
+be.o: be.cpp be.h
+	# $(CC) $(CFLAGS) -o be be.cpp -lncurses -framework OpenAL
+	$(CC) $(CFLAGS) -c be.cpp
+
+be: be.o se.o
+	$(CC) $(CFLAGS) -o be be.o se.o -lncurses -framework OpenAL
 
 .PHONY: install
 install:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build: be.cpp be.h sounds/ses.h
 install: build
 	mkdir -p ${HOME}/.local/bin
 	mv be ${HOME}/.local/bin/be
-	echo 'Installed to ${HOME}/.local/bin'
+	@echo 'Installed to ${HOME}/.local/bin'
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,11 @@ CFLAGS=-O -Wall
 .PHONY: all
 all: build
 
-data/ses.h: data/shinobi_execution_se.wav
-	xxd -i data/shinobi_execution_se.wav > data/ses.h
+sounds/ses.h: sounds/shinobi_execution_se.wav
+	xxd -i sounds/shinobi_execution_se.wav > sounds/ses.h
 
 .PHONY: build
-build: be.cpp be.h data/ses.h
+build: be.cpp be.h sounds/ses.h
 	$(CC) $(CFLAGS) -o be be.cpp -lncurses -framework OpenAL
 
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -12,17 +12,11 @@ CC=g++
 CFLAGS=-O -Wall
 
 .PHONY: all
-all: be install
+all: build install
 
-se.o: data/se.wav
-	gobjcopy -S -I binary -O mach-o-x86-64 data/se.wav se.o
-
-be.o: be.cpp be.h
-	# $(CC) $(CFLAGS) -o be be.cpp -lncurses -framework OpenAL
-	$(CC) $(CFLAGS) -c be.cpp
-
-be: be.o se.o
-	$(CC) $(CFLAGS) -o be be.o se.o -lncurses -framework OpenAL
+.PHONY: build
+build: be.cpp be.h
+	$(CC) $(CFLAGS) -o be be.cpp -lncurses -framework OpenAL
 
 .PHONY: install
 install:

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 - g++
 
 ## Usage
-1. data/shinobi_execution_se.wavを用意します
+1. sounds/shinobi_execution_se.wavを用意します
 
 1. 
 ```
 $ make
-$ be
+$ ./be
 ```
 
 ## 注意

--- a/be.cpp
+++ b/be.cpp
@@ -54,7 +54,7 @@
 #include <OpenAL/al.h>
 #include <OpenAL/alc.h>
 #include "be.h"
-#include "data/ses.h"
+#include "sounds/ses.h"
 
 int my_mvaddstr(int y, int x, char *str) {
     for ( ; x < 0; ++x, ++str)

--- a/be.cpp
+++ b/be.cpp
@@ -45,6 +45,7 @@
 
 #include <curses.h>
 #include <fstream>
+#include <sstream>
 #include <iostream>
 #include <signal.h>
 #include <stdio.h>
@@ -53,6 +54,7 @@
 #include <OpenAL/al.h>
 #include <OpenAL/alc.h>
 #include "be.h"
+#include "data/ses.h"
 
 int my_mvaddstr(int y, int x, char *str) {
     for ( ; x < 0; ++x, ++str)
@@ -142,10 +144,13 @@ static int convert_to_int(char* buffer, int len) {
 }
 
 //Location and size of data is found here: http://www.topherlee.com/software/pcm-tut-wavformat.html
-static char* load_wav(std::string filename, int& channels, int& sampleRate, int& bps, int& size) {
+static char* load_wav(const unsigned char* array, const unsigned int arraysize, int& channels, int& sampleRate, int& bps, int& size) {
   char buffer[4];
+  std::stringstream in;
+  for(int i=0; i < arraysize; i++) {
+    in << array[i];
+  }
 
-  std::ifstream in(filename.c_str());
   in.read(buffer, 4);
 
   if(strncmp(buffer, "RIFF", 4) != 0) {
@@ -216,7 +221,7 @@ static char* load_wav(std::string filename, int& channels, int& sampleRate, int&
 
   in.read(data, size);//Read audio data into buffer, return.
 
-  in.close();
+  // in.close();
 
   return data;    
 }
@@ -252,7 +257,7 @@ int main(int argc, char *argv[]) {
   attrset(COLOR_PAIR(1));
 
   // initialize OpenAL
-  data = load_wav("data/shinobi_execution_se.wav", channel, sample_rate, bps, size);
+  data = load_wav(data_shinobi_execution_se_wav, data_shinobi_execution_se_wav_len, channel, sample_rate, bps, size);
   device = alcOpenDevice(nullptr);
   if (!device) {
     std::cout << "Could not open sound device" << std::endl;


### PR DESCRIPTION
## 背景
- 音声ファイルのパスを決め打ちして内部で読み込みしてると、音声ファイルの削除・移動に弱すぎるため

## 内容
- `xxd -i` した内容をヘッダとして用意し、それをインクルードして無理やり埋め込むようにした